### PR TITLE
Expand-Object feature

### DIFF
--- a/CloudRemoting.psd1
+++ b/CloudRemoting.psd1
@@ -10,7 +10,7 @@
 RootModule = 'CloudRemoting.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.3.0'
+ModuleVersion = '0.6.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'd58ec090-b8b8-40ee-8292-049de3f17f4c'
@@ -88,6 +88,8 @@ FunctionsToExport = @(
     'Set-DefaultSSMOutput'
     'Clear-DefaultSSMOutput'
     'Invoke-SSMCommand'
+
+    'Expand-Object'
 )
 
 # Cmdlets to export from this module

--- a/Functions/AWS/SSM/Invoke-SSMCommand.ps1
+++ b/Functions/AWS/SSM/Invoke-SSMCommand.ps1
@@ -165,7 +165,9 @@ function Invoke-SSMCommand {
             if ($TimeoutSecond) { $SSMCommandArgs.TimeoutSecond = $TimeoutSecond }
 
             try {
-                $ssmCommand=Send-SSMCommand @SSMCommandArgs
+                $ssmCommand=Send-SSMCommand @SSMCommandArgs |
+                    Add-Member -NotePropertyName SSMCommandInputObject -NotePropertyValue $i -PassThru -Force
+
                 $script:SSMInvocations.$id = $ssmCommand
             } catch {
                 Write-Error $_.Exception
@@ -185,7 +187,8 @@ function Invoke-SSMCommand {
 
             if (($null -eq $currentCommand) -or ($currentCommand.Status -imatch 'Success|Fail')) {
                 $script:SSMInvocations.Remove($id)
-                Get-SSMCommandResult -CommandId $i.CommandId -InstanceId $id -EnableCliXml:$EnableCliXml
+                Get-SSMCommandResult -CommandId $i.CommandId -InstanceId $id -EnableCliXml:$EnableCliXml |
+                Add-Member -NotePropertyName SSMCommandInputObject -NotePropertyValue $i.SSMCommandInputObject -PassThru -Force
             }
             Start-Sleep -Milliseconds $SleepMilliseconds
         }

--- a/Functions/Expand-Object.ps1
+++ b/Functions/Expand-Object.ps1
@@ -1,0 +1,53 @@
+﻿<#
+.SYNOPSIS
+    Enriches the inputobject, by expanding properties to the top
+    level.
+.DESCRIPTION
+    Expands the InputObject with the -ExpandProperty and merges its
+    content to the top level.
+
+.PARAMETER InputObject
+    Mandatory - InputObject to be expanded
+.PARAMETER Force
+    Optional - Switch to to override properties that already exist
+
+.EXAMPLE
+    Invoke-SSMCommand { Get-Date } -EnableCliXml | Expand-Object -Force
+#>
+function Expand-Object {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [PsObject[]]$InputObject,
+
+        [Parameter()]
+        [Alias('Property')]
+        [string[]]$ExpandProperty=@('Tags','SSMCommandInputObject'),
+
+        [Parameter()]
+        [switch]$Force
+    )
+
+    process {
+        $InputObject |
+        ForEach-Object {
+            foreach ($expandable in ($_| Get-Member -Name $ExpandProperty | Select-Object -ExpandProperty Name)) {
+                Write-Verbose "Processing '$expandable'.."
+                if ($_.$expandable | Get-Member -Name @('Key','Value') -ErrorAction SilentlyContinue) {
+                    Write-Verbose "Hash expansion"
+                    foreach($enty in $_.$expandable) {
+                        $_ | Add-Member -NotePropertyName $enty.Key -NotePropertyValue $enty.Value -Force:$Force
+                    }
+                }
+                elseif ($_.$expandable) {
+                    Write-Verbose "PSObject expansion"
+                    foreach($property in ($_.$expandable | Get-Member -MemberType Properties)) {
+                        $_ | Add-Member -NotePropertyName $property.Name -NotePropertyValue $_.$expandable.($Property.Name) -Force:$Force
+                    }
+                }
+
+                $_
+            }
+        }
+    }
+}

--- a/Tests/Module/expected_commands.csv
+++ b/Tests/Module/expected_commands.csv
@@ -12,3 +12,4 @@ Set-DefaultEC2Pemfile
 Set-DefaultSSMOutput
 Clear-DefaultSSMOutput
 Invoke-SSMCommand
+Expand-Object


### PR DESCRIPTION
This change adds `SSMCommandInputObject` to SSM results and `Expand-Object` to merge expanded properties to the top level of the results for Tag expansions.

