### PR TITLE
Pass original error records instead of string representations

### DIFF
--- a/Functions/AWS/New-EC2PSSession.ps1
+++ b/Functions/AWS/New-EC2PSSession.ps1
@@ -77,7 +77,7 @@ function New-EC2PSSession {
                             return $session
                         }
                     } catch {
-                        Write-Error $_
+                        Write-Error -ErrorRecord $_
                     }
                 }
             } else {

--- a/Functions/AWS/SSM/Invoke-SSMCommand.ps1
+++ b/Functions/AWS/SSM/Invoke-SSMCommand.ps1
@@ -170,7 +170,7 @@ function Invoke-SSMCommand {
 
                 $script:SSMInvocations.$id = $ssmCommand
             } catch {
-                Write-Error $_.Exception
+                Write-Error -ErrorRecord $_
                 continue
             }
         }


### PR DESCRIPTION
While working with Invoke-SSMCommand, I noticed that the errors it would output would sometimes have nothing but a "Message" property, containing what should have been a bunch of useful information in object properties, like this:

```
$error[0].exception | fl * -Force


Message        : System.InvalidOperationException: Error making request with Error Code InvalidInstanceId and Http
                 Status Code BadRequest. No further error information was returned by the service. --->
                 Amazon.SimpleSystemsManagement.Model.InvalidInstanceIdException: Error making request with Error Code
                 InvalidInstanceId and Http Status Code BadRequest. No further error information was returned by the
                 service. ---> Amazon.Runtime.Internal.HttpErrorResponseException: The remote server returned an
                 error: (400) Bad Request. ---> System.Net.WebException: The remote server returned an error: (400)
                 Bad Request.
                    at System.Net.HttpWebRequest.GetResponse()
                    at Amazon.Runtime.Internal.HttpRequest.GetResponse()
                    --- End of inner exception stack trace ---
                    at Amazon.Runtime.Internal.HttpRequest.GetResponse()
                    at Amazon.Runtime.Internal.HttpHandler`1.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.Unmarshaller.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.ErrorHandler.InvokeSync(IExecutionContext executionContext)
                    --- End of inner exception stack trace ---
                    at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleException(IExecutionContext
                 executionContext, HttpErrorResponseException exception)
                    at Amazon.Runtime.Internal.ErrorHandler.ProcessException(IExecutionContext executionContext,
                 Exception exception)
                    at Amazon.Runtime.Internal.ErrorHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.CallbackHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.RetryHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.CallbackHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.CallbackHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.ErrorCallbackHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.MetricsHandler.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.Internal.RuntimePipeline.InvokeSync(IExecutionContext executionContext)
                    at Amazon.Runtime.AmazonServiceClient.Invoke[TRequest,TResponse](TRequest request, IMarshaller`2
                 marshaller, ResponseUnmarshaller unmarshaller)
                    at
                 Amazon.SimpleSystemsManagement.AmazonSimpleSystemsManagementClient.SendCommand(SendCommandRequest
                 request)
                    at Amazon.PowerShell.Cmdlets.SSM.SendSSMCommandCmdlet.Execute(ExecutorContext context)
                    --- End of inner exception stack trace ---
                    at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
Data           : {}
InnerException :
TargetSite     :
StackTrace     :
HelpLink       :
Source         :
HResult        : -2146233087
```

This was due to using a positional argument to `Write-Error`, which happens to bind to the string `-Message` parameter.  By changing those calls to `Write-Error` to use the `-ErrorRecord` argument instead, we'll be able to handle the errors much more cleanly (having access to the original Exception / InnerException objects, etc.)