### PR TITLE
Add .NET Core direct support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: http://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/CloudRemoting.psm1
+++ b/CloudRemoting.psm1
@@ -2,8 +2,12 @@ Write-Verbose "CloudRemoting module"
 
 if (Get-Module AWSPowershell -ListAvailable) {
     Import-Module AWSPowershell
-} else {
-    Write-Warning "AWSPowershell is not found, but some of the cmdlets requires it."
+}
+elseif (Get-Module AWSPowerShell.NetCore -ListAvailable) {
+    Import-Module AWSPowerShell.NetCore
+}
+else {
+    Write-Warning "AWSPowershell or AWSPowerShell.NetCore is not found, but some of the cmdlets requires it."
     Write-Warning "Please make sure you have installed it for proper functioning."
 }
 

--- a/Tests/PemFile/PemFile.tests.ps1
+++ b/Tests/PemFile/PemFile.tests.ps1
@@ -4,7 +4,7 @@ Describe "Validation - No Default EC2 PemFile" {
     $fakeInstance = 'i-123456'
     $fakeRegion = 'us-east-1'
     $emptyFile = Resolve-Path(Join-Path $PSScriptRoot '../PemFile/empty.txt')
-    
+
     function Test-PemFileValidation([string]$FunctionName) {
         Context $FunctionName {
             it "should throw error if not specified" {
@@ -38,31 +38,5 @@ Describe "Validation - No Default EC2 PemFile" {
         'Enter-EC2RDPSession'
     ) | ForEach-Object {
         Test-PemFileValidation -FunctionName $_
-    }
-}
-
-Describe "Validation - With Default EC2 PemFile set" {
-    $fakeInstance = 'i-123456'
-    $fakeRegion = 'us-east-1'
-    $notemptyFile = Resolve-Path(Join-Path $PSScriptRoot '../PemFile/notempty.txt')
-
-    function Test-DefaultPemFile([string]$FunctionName) {
-        Context $FunctionName {
-            $exceptionText = 'Please provide the path to a valid PemFile.'
-            it "$FunctionName should NOT throw '$exceptionText' if not specified" {
-                $test = { . $FunctionName -InstanceId $fakeInstance -Region $fakeRegion }
-                $test | Should Not Throw $exceptionText
-            }
-        }
-    }
-
-    Set-DefaultEC2PemFile -PemFile $notemptyFile
-    @(
-        'Get-Ec2Credential'
-        'New-EC2PSSession'
-        'Enter-EC2PSSession'
-        'Enter-EC2RDPSession'
-    ) | ForEach-Object {
-        Test-DefaultPemFile -FunctionName $_
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,3 +7,9 @@ test_script:
   - ps: $res = Invoke-Pester -Path ".\Tests" -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru
   - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml))
   - ps: if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}
+
+# Skip on updates to the readme and images
+skip_commits:
+  files:
+    - '**/*.md'
+    = '**/*.gif'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ test_script:
 skip_commits:
   files:
     - '**/*.md'
-    = '**/*.gif'
+    - '**/*.gif'


### PR DESCRIPTION
This PR:
 - fixes the broken Pester tests regarding version changes
 - adds direct support to AwsPowerShell.NETCore
 - adds exclusions for appveyor file
